### PR TITLE
[REFACTOR] Update API to introduce service interfaces

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,5 @@
+import { getServiceName } from 'ember-totally-not-module-based-services/-private';
+
+export function registerMockService(owner, ServiceClass, MockClass) {
+  owner.register(getServiceName(ServiceClass), MockClass);
+}

--- a/addon/-private/index.js
+++ b/addon/-private/index.js
@@ -1,0 +1,54 @@
+import { assert } from '@ember/debug';
+import { DEBUG } from '@glimmer/env';
+
+export let isServiceInterface;
+export let setServiceInterface;
+export let getServiceInterfaceFor;
+
+if (DEBUG) {
+  let SERVICES_INTERFACES = new WeakSet();
+
+  isServiceInterface = (Class) => {
+    return SERVICES_INTERFACES.has(Class);
+  };
+
+  setServiceInterface = (Class) => {
+    SERVICES_INTERFACES.add(Class);
+  };
+
+  getServiceInterfaceFor = (Class) => {
+    let current = Object.getPrototypeOf(Class);
+
+    while (current !== null) {
+      if (SERVICES_INTERFACES.has(current)) {
+        return current;
+      }
+
+      current = Object.getPrototypeOf(current);
+    }
+  }
+}
+
+const NONCE = Math.random()
+  .toString(36)
+  .substring(2);
+
+export function getClassName(Class) {
+  return (
+    Class.name || (Class.toString().match(/function (.+?)\(/) || ['', ''])[1]
+  );
+}
+
+export function getServiceName(Class) {
+  let className = getClassName(Class);
+
+  return `service:totally-not-modules_${className}_${NONCE}`;
+}
+
+export function registerService(owner, InterfaceClass, ImplClass) {
+  assert(`${getClassName(InterfaceClass)} isn't a service interface. Classes you attempt to override must be interfaces. Interfaces represent a contract that an implementation can fulfill, and must be decorated with the @serviceInterface decorator. Implementations can then be registered in place of the interface. To find out more about service interfaces, check out the docs: https://github.com/pzuraq/ember-totally-not-module-based-services#service-interfaces`, isServiceInterface(InterfaceClass));
+
+  assert(`${getClassName(ImplClass)} isn't a subclass of ${getClassName(InterfaceClass)}. Implementations of an interface must be subclasses of the interface.`, ImplClass.prototype instanceof InterfaceClass);
+
+  owner.register(getServiceName(InterfaceClass), ImplClass);
+}

--- a/addon/index.js
+++ b/addon/index.js
@@ -3,41 +3,20 @@ import { getOwner } from '@ember/application';
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
 
-let REGISTERED_SERVICES;
-let getRegisteredServicesFor;
-
-if (DEBUG) {
-  REGISTERED_SERVICES = new WeakMap();
-
-  getRegisteredServicesFor = function(owner) {
-    let registeredServices = REGISTERED_SERVICES.get(owner);
-
-    if (registeredServices === undefined) {
-      registeredServices = new WeakSet();
-      REGISTERED_SERVICES.set(owner, registeredServices);
-    }
-
-    return registeredServices;
-  };
-}
-
-const NONCE = Math.random()
-  .toString(36)
-  .substring(2);
-
-function getClassName(Class) {
-  return (
-    Class.name || (Class.toString().match(/function (.+?)\(/) || ['', ''])[1]
-  );
-}
-
-function getServiceName(Class) {
-  let className = getClassName(Class);
-
-  return `service:totally-not-modules_${className}_${NONCE}`;
-}
+import {
+  setServiceInterface,
+  getServiceInterfaceFor,
+  getServiceName,
+  getClassName
+} from './-private';
 
 export function service(Class) {
+  if (DEBUG) {
+    let InterfaceClass = getServiceInterfaceFor(Class);
+
+    assert(`You attempted to inject ${getClassName(Class)}, but it is an implementation of the ${getClassName(InterfaceClass)} service interface. Service interfaces are a way to define a contract that an implementation can fulfill, and you must inject the interface instead: @service(${getClassName(InterfaceClass)}). To find out more about service interfaces, check out the docs: https://github.com/pzuraq/ember-totally-not-module-based-services#service-interfaces`, !InterfaceClass);
+  }
+
   let serviceName = getServiceName(Class);
 
   return computed({
@@ -46,9 +25,6 @@ export function service(Class) {
       let serviceInstance = owner.lookup(serviceName);
 
       if (serviceInstance === undefined) {
-        if (DEBUG) {
-          getRegisteredServicesFor(owner).add(Class);
-        }
         owner.register(serviceName, Class);
         serviceInstance = owner.lookup(serviceName);
       }
@@ -58,40 +34,18 @@ export function service(Class) {
   });
 }
 
-export function lookup(owner, Class) {
-  return owner.lookup(getServiceName(Class));
-}
-
-export function register(owner, BaseClass, SubClass) {
-  assert(
-    `Attempted to register ${getClassName(
-      BaseClass
-    )} as itself, which is not necessary. An instance of the class will be created, no need to register it.`,
-    SubClass !== BaseClass
-  );
-
-  assert(
-    `Attempted to register ${getClassName(SubClass)} in place of ${getClassName(
-      BaseClass
-    )}, but it is not a subclass of the injection. When you want to override an injected class, you must provide a subclass of that class instead. This restriction is put in place to prevent confusion, since registering a completely unrelated class may be counter-intuitive. If you have two separate implementations of a class, you should create a single base class that they extend from. If you attempting to stub the class for tests, you can extend it directly and stub the public API methods that it exposes.`,
-    SubClass.prototype instanceof BaseClass
-  );
-
-  assert(
-    `Attempted to register ${getClassName(SubClass)} in place of ${getClassName(
-      BaseClass
-    )}, but ${getClassName(
-      SubClass
-    )} was already registered as its own service, or in place of another service. You may have injected it directly into a class when you meant to inject the ${getClassName(
-      BaseClass
-    )} base class instead.`,
-    !getRegisteredServicesFor(owner).has(SubClass)
-  );
-
+export function serviceInterface(Class) {
   if (DEBUG) {
-    getRegisteredServicesFor(owner).add(BaseClass);
-    getRegisteredServicesFor(owner).add(SubClass);
+    let InterfaceClass = getServiceInterfaceFor(Class);
+
+    assert(`You attempted to decorate ${getClassName(Class)} as a service interface, but it is an implementation of a service interface: ${getClassName(InterfaceClass)}.`, !InterfaceClass);
   }
 
-  owner.register(getServiceName(BaseClass), SubClass);
+  setServiceInterface(Class);
+
+  return Class;
+}
+
+export function lookup(owner, Class) {
+  return owner.lookup(getServiceName(Class));
 }

--- a/tests/acceptance/service-test.js
+++ b/tests/acceptance/service-test.js
@@ -1,8 +1,13 @@
 import { module, test } from 'qunit';
+import Service from '@ember/service';
 import { find, visit, settled } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { lookup, register } from 'ember-totally-not-module-based-services';
-import { SomeService } from 'dummy/services/some';
+
+import { lookup, service, serviceInterface } from 'ember-totally-not-module-based-services';
+import { registerService } from 'ember-totally-not-module-based-services/-private';
+import { registerMockService } from 'ember-totally-not-module-based-services/test-support';
+
+import { SomeService, SomeServiceInterface, SomeServiceImplementation } from 'dummy/services/some';
 
 module('Acceptance | service', function(hooks) {
   setupApplicationTest(hooks);
@@ -23,17 +28,35 @@ module('Acceptance | service', function(hooks) {
     );
 
     assert.equal(
-      find('[data-test-another-value]').textContent,
+      find('[data-test-interface-value]').textContent,
       789,
       'dependency overridden correctly'
     );
   });
 
-  test('can override a service in tests', async function(assert) {
-    register(
+  test('can override a service interface with register if the service is a subclass', async function(assert) {
+    registerService(
+      this.owner,
+      SomeServiceInterface,
+      class extends SomeServiceInterface {
+        value = 456;
+      }
+    );
+
+    await visit('/');
+
+    assert.equal(
+      find('[data-test-interface-value]').textContent,
+      456,
+      'dependency injected correctly'
+    );
+  });
+
+  test('can override a service with registerMockService with any service', async function(assert) {
+    registerMockService(
       this.owner,
       SomeService,
-      class extends SomeService {
+      class extends Service {
         value = 456;
       }
     );
@@ -48,6 +71,24 @@ module('Acceptance | service', function(hooks) {
 
     assert.equal(
       find('[data-test-same-value]').textContent,
+      456,
+      'dependency injected correctly'
+    );
+  });
+
+  test('can override a service interface with registerMockService with any service', async function(assert) {
+    registerMockService(
+      this.owner,
+      SomeServiceInterface,
+      class extends Service {
+        value = 456;
+      }
+    );
+
+    await visit('/');
+
+    assert.equal(
+      find('[data-test-interface-value]').textContent,
       456,
       'dependency injected correctly'
     );
@@ -84,25 +125,40 @@ module('Acceptance | service', function(hooks) {
     );
   });
 
-  test('throws an error if you try to register a class to itself', async function(assert) {
+  test('throws an error if you try to register to a class that is not an interface', async function(assert) {
     assert.throws(() => {
-      register(this.owner, SomeService, SomeService);
-    }, /Attempted to register SomeService as itself, which is not necessary. An instance of the class will be created, no need to register it./);
+      registerService(this.owner, class Foo {}, class Bar {});
+    }, /Assertion Failed: Foo isn't a service interface. Classes you attempt to override must be interfaces./);
   });
 
   test('throws an error if you try to register a class that is not a subclass', async function(assert) {
     assert.throws(() => {
-      register(this.owner, SomeService, class ADifferentClass {});
-    }, /Attempted to register ADifferentClass in place of SomeService, but it is not a subclass of the injection/);
+      registerService(this.owner, SomeServiceInterface, class ADifferentClass {});
+    }, /Assertion Failed: ADifferentClass isn't a subclass of SomeServiceInterface. Implementations of an interface must be subclasses of the interface./);
   });
 
-  test('throws an error if you try to override a class with a subclass that has already been registered/used', async function(assert) {
+  test('throws an error if you try to register an interface to itself', async function(assert) {
     assert.throws(() => {
-      class Foo extends SomeService {}
-      class Bar extends Foo {}
+      registerService(this.owner, SomeServiceInterface, SomeServiceInterface);
+    }, /Assertion Failed: SomeServiceInterface isn't a subclass of SomeServiceInterface. Implementations of an interface must be subclasses of the interface./);
+  });
 
-      register(this.owner, Foo, Bar);
-      register(this.owner, SomeService, Bar);
-    }, /Attempted to register Bar in place of SomeService, but Bar was already registered as its own service, or in place of another service./);
+  test('throws an error if you try to inject a service interface implemenation', async function(assert) {
+    assert.throws(() => {
+      class Foo {
+        @service(SomeServiceImplementation) some;
+      }
+
+      new Foo();
+    }, /Assertion Failed: You attempted to inject SomeServiceImplementation, but it is an implementation of the SomeServiceInterface service interface./);
+  });
+
+  test('throws an error if you try to decorate a class that is an implementation of a service interface', async function(assert) {
+    assert.throws(() => {
+      @serviceInterface
+      class Foo extends SomeServiceInterface {}
+
+      new Foo();
+    }, /Assertion Failed: You attempted to decorate Foo as a service interface, but it is an implementation of a service interface: SomeServiceInterface./);
   });
 });

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,11 +3,18 @@ import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-  Resolver
-});
+import { SomeServiceInterface, SomeServiceImplementation } from './services/some';
+
+class App extends Application {
+  Resolver = Resolver;
+
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+
+  serviceOverrides = [
+    [SomeServiceInterface, SomeServiceImplementation],
+  ];
+}
 
 loadInitializers(App, config.modulePrefix);
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,10 +1,10 @@
 import Controller from '@ember/controller';
-import { AnotherService, SomeService } from '../services/some';
+import { SomeService, SomeServiceInterface } from '../services/some';
 
 import { service } from 'ember-totally-not-module-based-services';
 
 export default class ApplicationController extends Controller {
   @service(SomeService) some;
   @service(SomeService) same;
-  @service(AnotherService) another;
+  @service(SomeServiceInterface) interface;
 }

--- a/tests/dummy/app/instance-initializers/override-service.js
+++ b/tests/dummy/app/instance-initializers/override-service.js
@@ -1,8 +1,11 @@
-import { register } from 'ember-totally-not-module-based-services';
-import { AnotherService, OverrideService } from '../services/some';
+import { registerService } from 'ember-totally-not-module-based-services/-private';
 
 export function initialize(appInstance) {
-  register(appInstance, AnotherService, OverrideService);
+  let overrides = appInstance.base.serviceOverrides || [];
+
+  overrides.forEach(([InterfaceClass, ImplClass]) => {
+    registerService(appInstance, InterfaceClass, ImplClass);
+  });
 }
 
 export default {

--- a/tests/dummy/app/services/some.js
+++ b/tests/dummy/app/services/some.js
@@ -1,13 +1,15 @@
 import Service from '@ember/service';
+import { serviceInterface } from 'ember-totally-not-module-based-services';
 
 export class SomeService extends Service {
   value = 123;
 }
 
-export class AnotherService extends Service {
+@serviceInterface
+export class SomeServiceInterface extends Service {
   value = 456;
 }
 
-export class OverrideService extends AnotherService {
+export class SomeServiceImplementation extends SomeServiceInterface {
   value = 789;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
 <div data-test-some-value>{{this.some.value}}</div>
 <div data-test-same-value>{{this.same.value}}</div>
-<div data-test-another-value>{{this.another.value}}</div>
+<div data-test-interface-value>{{this.interface.value}}</div>


### PR DESCRIPTION
Refactors the addon to introduce a concept of service interfaces, along
with adding `serviceOverrides` directly to the app definition. This
makes overriding a service more restrictive, but simplifies the overall
rules for how overriding works. It also ensures that users can trust
their tooling, since they'll see whenever they click on a service if it
is a concrete definition, or an interface.